### PR TITLE
Coloração de branch com base em status

### DIFF
--- a/ps1.sh
+++ b/ps1.sh
@@ -1,6 +1,34 @@
-function git_branch() {
-    echo -ne '\033[0;33m'
-    echo -n "" $(git branch &> /dev/stdout|grep ^\*|sed 's/\* \(.*\)/ \(\1\) /')
+c_cyan=`tput setaf 6`
+c_red=`tput setaf 1`
+c_green=`tput setaf 2`
+c_sgr0=`tput sgr0`
+
+function branch_color ()
+{
+    if git rev-parse --git-dir >/dev/null 2>&1
+    then
+        color=""
+        if git diff --quiet 2>/dev/null >&2 
+        then
+            color="${c_green}"
+        else
+            color=${c_red}
+        fi
+    else
+        return 0
+    fi
+    echo -ne $color
+}
+
+function git_branch ()
+{
+    if git rev-parse --git-dir >/dev/null 2>&1
+    then
+        gitver=$(git branch 2>/dev/null| sed -n '/^\*/s/^\* //p')
+    else
+        return 0
+    fi
+    echo -e " ("$gitver")"
 }
 
 function python_version() {
@@ -18,8 +46,18 @@ function django_version() {
 }
 
 function linebreak() {
-    echo -e '\033[00m\n$ ';
+    echo -e '\n\033[00m'$(basename `pwd`) '$ ';
 }
 
-export PS1="\[\e]0;\u@\h: \w\a\\u@\h:\w"
-export PS1="$PS1\`git_branch\`\`python_version\`\`django_version\`\`linebreak\`"
+b_is_pythonist=1
+
+export PS1="\[\e]0;\u@\h: \w\a\\u@\h:"
+export PS1="$PS1\`branch_color\`\`git_branch\`"
+
+if [ $b_is_pythonist -ne 0 ]
+then
+    export PS1="$PS1\`python_version\`\`django_version\`"
+fi
+
+
+export PS1="$PS1\`linebreak\`"

--- a/ps1.sh
+++ b/ps1.sh
@@ -46,12 +46,12 @@ function django_version() {
 }
 
 function linebreak() {
-    echo -e '\n\033[00m'$(basename `pwd`) '$ ';
+    echo -e '\n\033[00m$ ';
 }
 
 b_is_pythonist=1
 
-export PS1="\[\e]0;\u@\h: \w\a\\u@\h:"
+export PS1="\u@\h $c_cyan\w"
 export PS1="$PS1\`branch_color\`\`git_branch\`"
 
 if [ $b_is_pythonist -ne 0 ]


### PR DESCRIPTION
- Modificação na exibição de _branches_ baseados no status da cópia de trabalho, mostrando o nome do _branch_ em vermelho caso haja modificações; ou verde em caso de cópia "limpa" - baseado no post/comentários publicados em [asemanfar.com](http://goo.gl/7Bov5)
- Coloração do diretório de trabalho atual
- Adicionada condição p/ desabilitar a exibição de informações sobre python+django
